### PR TITLE
Deprecate animation plugin and update Tailwind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- n/a
+
 ## [0.0.11] - 09-15-2020
 ### Fixed
 - Fixed missing export, missing README update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.9] - 08-25-2020
 ### Added
 - Added .sr-undo-absolute utility
+- Added testing via CircleCI
 
 ## [0.0.8] - 05-06-2020
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated Tailwind to 1.6
 
+### Deprecated
+- Deprecated animation plugin, consider using Tailwind's animation utilities (1.6+) instead
+
 ## [0.0.11] - 09-15-2020
 ### Fixed
 - Fixed missing export, missing README update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - n/a
 
+### Changed
+- Updated Tailwind to 1.6
+
 ## [0.0.11] - 09-15-2020
 ### Fixed
 - Fixed missing export, missing README update

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "lodash": "^4.17.15",
     "postcss": "^7.0.29",
     "prettier": "^2.0.5",
-    "tailwindcss": "^1.2.0"
+    "tailwindcss": "^1.6.0"
   }
 }

--- a/plugins/animation/README.md
+++ b/plugins/animation/README.md
@@ -1,5 +1,7 @@
 # animation
 
+_This plugin has been **deprecated**. Consider using Tailwind's animation utilities (1.6+) instead._
+
 This plugin adds [animation](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) utilities with [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes) to Tailwind.
 
 ## Usage


### PR DESCRIPTION
_Update: we discussed at the FED onsite the idea of NOT removing the animation plugin, but rather, marking it for deprecation. ~I will update this PR accordingly when I have some time.~ This work is done._

* Updates Tailwind to 1.6
* ~Removes~ Deprecates the animation plugin
* Adds an unreleased section to the changelog