### PR TITLE
Add sr-undo-absolute utility for skip links

### DIFF
--- a/plugins/sr/README.md
+++ b/plugins/sr/README.md
@@ -40,4 +40,23 @@ The above configuration would create the following css, as well as their respons
   position: static;
   width: auto;
 }
+
+.sr-undo-absolute {
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: absolute;
+  width: auto;
+}
+```
+
+## Skip Links
+
+The `.sr-undo-absolute` utility is especially helpful for skip links, when you want to preserve `position: absolute`.
+
+For example:
+
+```html
+<a href="#content" class="sr-only focus:sr-undo-absolute">Skip to Main Content</a>
 ```

--- a/plugins/sr/index.js
+++ b/plugins/sr/index.js
@@ -22,6 +22,14 @@ module.exports = plugin(({ addUtilities, variants }) => {
       position: 'static',
       width: 'auto',
     },
+    '.sr-undo-absolute': {
+      clip: 'auto',
+      height: 'auto',
+      margin: '0',
+      overflow: 'visible',
+      position: 'absolute',
+      width: 'auto',
+    },
   }
 
   addUtilities(sr, pluginVariants)

--- a/plugins/sr/test.js
+++ b/plugins/sr/test.js
@@ -34,6 +34,15 @@ test('it generates the sr classes', () => {
       width: auto;
     }
 
+    .sr-undo-absolute {
+      clip: auto;
+      height: auto;
+      margin: 0;
+      overflow: visible;
+      position: absolute;
+      width: auto;
+    }
+
     .focus\\:sr-only:focus {
       border: 0;
       clip: rect(0 0 0 0);
@@ -51,6 +60,15 @@ test('it generates the sr classes', () => {
       margin: 0;
       overflow: visible;
       position: static;
+      width: auto;
+    }
+
+    .focus\\:sr-undo-absolute:focus {
+      clip: auto;
+      height: auto;
+      margin: 0;
+      overflow: visible;
+      position: absolute;
       width: auto;
     }
   `


### PR DESCRIPTION
This is a handy class for skip links, because you can't use `sr-undo` (its `position: static` is more specific than the `absolute` utility) and manually undoing the classes means adding a plugin for `clip` and the `focus` variant for several modules that otherwise wouldn't need it (adding more time to the compilation).