### PR TITLE
Animate Plugin

### DIFF
--- a/plugins/animate/README.md
+++ b/plugins/animate/README.md
@@ -32,6 +32,13 @@ theme: {
           opacity: 1,
         },
       },
+      'zoom-in': {
+        from: {
+          transform: 'scale(0.8)',
+          opacity: 0,
+        },
+        // "to" is optional
+      },
     },
   }),
 },
@@ -110,4 +117,4 @@ The `transition-delay` used to power the staggered animation are calculated via 
 
 ### `animations`
 
-Specify the animation styles. The first-level object names the animation, which in turn must specify `from` and `to` objects. These objects accept the same [CSS-in-JS syntax as Tailwind](https://tailwindcss.com/docs/plugins#css-in-js-syntax).
+Specify the animation styles. The first-level object names the animation, which in turn **must** specify a `from` object and optionally a `to` object. These objects accept the same [CSS-in-JS syntax as Tailwind](https://tailwindcss.com/docs/plugins#css-in-js-syntax).

--- a/plugins/animate/README.md
+++ b/plugins/animate/README.md
@@ -42,19 +42,23 @@ plugins: [
 
 ### Markup Examples
 
-- Animate a single element (pending addition of `triggerClass`)
+#### Animate a single element (pending addition of `triggerClass`)
 
 ```html
 <div class="animate-fade-up">Hello!</div>
 ```
 
-- Animate a single element after a delay
+---
+
+#### Animate a single element after a delay
 ```html
 <div class="animate-fade-up delay-200">Hello</div>
 ```
-N.b. `delay-` is a first-party Tailwind utility
+> N.b. `delay-` is a first-party Tailwind utility
 
-- Stagger the animation of multiple elements, using the specified default interval
+---
+
+#### Stagger the animation of multiple elements, using the specified default interval
 ```html
 <ul class="stagger-fade-up">
   <li class="duration-500">1</li>
@@ -62,9 +66,11 @@ N.b. `delay-` is a first-party Tailwind utility
   <li class="duration-500">3</li>
 </ul>
 ```
-N.b. `duration-` is a first-party Tailwind utility and **is required** on the child element unless a `transition-duration` is otherwise specified. This plugin doesn not apply a default duration in order to preserve customizability using the `duration-` utilities.
+> N.b. `duration-` is a first-party Tailwind utility and **is required** on the child element unless a `transition-duration` is otherwise specified. This plugin doesn not apply a default duration in order to preserve customizability using the `duration-` utilities.
 
-- Stagger the animation of multiple elements, overriding default interval
+---
+
+#### Stagger the animation of multiple elements, overriding default interval
 ```html
 <ul class="stagger-fade-up stagger-interval-200">
   <li class="duration-500">1</li>
@@ -73,7 +79,9 @@ N.b. `duration-` is a first-party Tailwind utility and **is required** on the ch
 </ul>
 ```
 
-- Stagger the animation of multiple elements, using specified interval, but delay the start
+---
+
+#### Stagger the animation of multiple elements, using specified interval, but delay the start
 ```html
 <ul class="stagger-fade-up stagger-interval-200 stagger-delay-100">
   <li class="duration-500">1</li>
@@ -84,17 +92,22 @@ N.b. `duration-` is a first-party Tailwind utility and **is required** on the ch
 
 ## Configuration
 
-- `triggerClass`
+### `triggerClass`
+
 Specify the class name that will be dynamically added to the element. Typically this class is added to indicate that the element has entered the viewport.
 
-- `staggerDelay`
+### `staggerDelay`
+
 Specify the delays for starting the staggered animations. It probably makes the most sense to simply set this to `theme('transitionDelay')`.
 
-- `staggerInterval`
+### `staggerInterval`
+
 Specify the amount of time in between the staggered animations. While optional, it is recommended to add a `default` entry to this object. Doing so allows you to use the `stagger-[animation]` class without specifying any `stagger-interval-[time]`.
 
-- `maxItemIntervalSupport`
+### `maxItemIntervalSupport`
+
 The `transition-delay` used to power the staggered animation are calculated via a custom property on the child elements called `--animate-index`. This setting allows you to decide how many `nth-child` selectors should be automatically output with this custom property so you do not need to add it by hand. 
 
-- `animations`
+### `animations`
+
 Specify the animation styles. The first-level object names the animation, which in turn must specify `from` and `to` objects. These objects accept the same [CSS-in-JS syntax as Tailwind](https://tailwindcss.com/docs/plugins#css-in-js-syntax).

--- a/plugins/animate/README.md
+++ b/plugins/animate/README.md
@@ -1,42 +1,100 @@
-# animation
+# animate
 
-This plugin adds [animation](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) utilities with [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes) to Tailwind.
+This plugin adds utilities for animating elements based on a dynamically added class. The main use case this addresses is animating elements in during scrolling. By adding a class via [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) or some other scroll listener, these utilities allow you to easily define the animations and apply staggered transitions. This has also been designed to work with the existing Tailwind utilities that control transition properties.
 
 ## Usage
 
+### Config Example
+
 ```js
 theme: {
-  animation: {
-    spin: {
-      animation: '1s infinite linear',
-      keyframes: {
-        from: { transform: 'rotate(0deg)' },
-        to: { transform: 'rotate(360deg)' },
+  animate: (theme) => ({
+    triggerClass: '-observed',
+    staggerDelay: {
+      '100': '100ms',
+      '200': '200ms',
+      ...theme('transitionDelay'),
+    },
+    staggerInterval: {
+      default: '100ms',
+      '200': '200ms',
+      ...theme('transitionDelay'),
+    },
+    maxItemIntervalSupport: 9,
+    animations: {
+      'fade-up': {
+        from: {
+          transform: 'translateY(20px)',
+          opacity: 0,
+        },
+        to: {
+          transform: 'translateY(0)',
+          opacity: 1,
+        },
       },
     },
-  },
+  }),
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/animation'),
+  require('@viget/tailwindcss-plugins/animate'),
 ],
 ```
 
-Note that this plugin does not accept **variants** so you do not need to add anything to that object.
+### Markup Examples
 
-The above configuration would create the following css:
+- Animate a single element (pending addition of `triggerClass`)
 
-```css
-.animation-spin {
-  animation: spin 1s infinite linear;
-}
-
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
-  }
-}
+```html
+<div class="animate-fade-up">Hello!</div>
 ```
+
+- Animate a single element after a delay
+```html
+<div class="animate-fade-up delay-200">Hello</div>
+```
+N.b. `delay-` is a first-party Tailwind utility
+
+- Stagger the animation of multiple elements, using the specified default interval
+```html
+<ul class="stagger-fade-up">
+  <li class="duration-500">1</li>
+  <li class="duration-500">2</li>
+  <li class="duration-500">3</li>
+</ul>
+```
+N.b. `duration-` is a first-party Tailwind utility and **is required** on the child element unless a `transition-duration` is otherwise specified. This plugin doesn not apply a default duration in order to preserve customizability using the `duration-` utilities.
+
+- Stagger the animation of multiple elements, overriding default interval
+```html
+<ul class="stagger-fade-up stagger-interval-200">
+  <li class="duration-500">1</li>
+  <li class="duration-500">2</li>
+  <li class="duration-500">3</li>
+</ul>
+```
+
+- Stagger the animation of multiple elements, using specified interval, but delay the start
+```html
+<ul class="stagger-fade-up stagger-interval-200 stagger-delay-100">
+  <li class="duration-500">1</li>
+  <li class="duration-500">2</li>
+  <li class="duration-500">3</li>
+</ul>
+```
+
+## Configuration
+
+- `triggerClass`
+Specify the class name that will be dynamically added to the element. Typically this class is added to indicate that the element has entered the viewport.
+
+- `staggerDelay`
+Specify the delays for starting the staggered animations. It probably makes the most sense to simply set this to `theme('transitionDelay')`.
+
+- `staggerInterval`
+Specify the amount of time in between the staggered animations. While optional, it is recommended to add a `default` entry to this object. Doing so allows you to use the `stagger-[animation]` class without specifying any `stagger-interval-[time]`.
+
+- `maxItemIntervalSupport`
+The `transition-delay` used to power the staggered animation are calculated via a custom property on the child elements called `--animate-index`. This setting allows you to decide how many `nth-child` selectors should be automatically output with this custom property so you do not need to add it by hand. 
+
+- `animations`
+Specify the animation styles. The first-level object names the animation, which in turn must specify `from` and `to` objects. These objects accept the same [CSS-in-JS syntax as Tailwind](https://tailwindcss.com/docs/plugins#css-in-js-syntax).

--- a/plugins/animate/README.md
+++ b/plugins/animate/README.md
@@ -1,0 +1,42 @@
+# animation
+
+This plugin adds [animation](https://developer.mozilla.org/en-US/docs/Web/CSS/animation) utilities with [@keyframes](https://developer.mozilla.org/en-US/docs/Web/CSS/@keyframes) to Tailwind.
+
+## Usage
+
+```js
+theme: {
+  animation: {
+    spin: {
+      animation: '1s infinite linear',
+      keyframes: {
+        from: { transform: 'rotate(0deg)' },
+        to: { transform: 'rotate(360deg)' },
+      },
+    },
+  },
+},
+plugins: [
+  require('@viget/tailwindcss-plugins/animation'),
+],
+```
+
+Note that this plugin does not accept **variants** so you do not need to add anything to that object.
+
+The above configuration would create the following css:
+
+```css
+.animation-spin {
+  animation: spin 1s infinite linear;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+```

--- a/plugins/animate/index.js
+++ b/plugins/animate/index.js
@@ -11,12 +11,26 @@ module.exports = plugin(({ addUtilities, e, theme }) => {
   } = pluginConfig
 
   const animationUtilities = Object.entries(animations).map(
-    ([name, config]) => ({
-      [`.${e(`animate-${name}`)}, .${e(`stagger-${name}`)} > *`]: config.from,
-      [`.${e(`animate-${name}`)}.${e(triggerClass)},.${e(
-        `stagger-${name}`,
-      )}.${triggerClass} > *`]: config.to,
-    }),
+    ([name, config]) => {
+      const from = {
+        [`.${e(`animate-${name}`)}:not(.${e(triggerClass)}), .${e(
+          `stagger-${name}`,
+        )}:not(.${e(triggerClass)}) > *`]: config.from,
+      }
+
+      const to = config.to
+        ? {
+            [`.${e(`animate-${name}`)}.${e(triggerClass)},.${e(
+              `stagger-${name}`,
+            )}.${triggerClass} > *`]: config.to,
+          }
+        : {}
+
+      return {
+        ...from,
+        ...to,
+      }
+    },
   )
 
   const staggerDefaultUtility = staggerInterval.default

--- a/plugins/animate/index.js
+++ b/plugins/animate/index.js
@@ -1,0 +1,55 @@
+const plugin = require('tailwindcss/plugin')
+
+module.exports = plugin(({ addUtilities, e, theme }) => {
+  const pluginConfig = theme('animate', {})
+  const {
+    triggerClass,
+    defaultDuration,
+    staggerDelay,
+    maxItemIntervalSupport,
+    animations,
+  } = pluginConfig
+
+  const animationUtilities = Object.entries(animations).map(
+    ([name, config]) => ({
+      [`.${e(`animate-${name}`)}, .${e(`stagger-${name}`)} > *`]: config.from,
+      [`.${e(`animate-${name}.${triggerClass}`)}, .${e(
+        `stagger-${name}.${triggerClass}`,
+      )} > *`]: config.to,
+    }),
+  )
+
+  const durationUtilities = [
+    {
+      ['[class*="animate-"], [class*="stagger-"] > *']: {
+        'transition-duration': `${defaultDuration}ms`,
+      },
+    },
+  ]
+
+  const staggerUtilities = Object.entries(staggerDelay).map(([name, value]) => {
+    const selector =
+      name === 'default'
+        ? '[class*="stagger-"] > *'
+        : `.${e(`stagger-delay-${name}`)} > *`
+
+    return {
+      [selector]: {
+        'transition-delay': `calc(var(--animate-index) * ${value}ms)`,
+      },
+    }
+  })
+
+  const nthChildUtilities = [...Array(maxItemIntervalSupport)].map((_, i) => ({
+    [`[class*="stagger"] > *:nth-child(${i + 1})`]: {
+      '--animate-index': `${i + 1}`,
+    },
+  }))
+
+  addUtilities([
+    ...animationUtilities,
+    ...durationUtilities,
+    ...staggerUtilities,
+    ...nthChildUtilities,
+  ])
+})

--- a/plugins/animate/test.js
+++ b/plugins/animate/test.js
@@ -11,10 +11,13 @@ test('it generates the animate classes', () => {
     theme: {
       animate: {
         triggerClass: '-observed',
-        defaultDuration: 200,
         staggerDelay: {
-          default: 50,
-          100: 100,
+          '100': '100ms',
+          '200': '200ms',
+        },
+        staggerInterval: {
+          default: '100ms',
+          '200': '200ms',
         },
         maxItemIntervalSupport: 5,
         animations: {
@@ -39,21 +42,27 @@ test('it generates the animate classes', () => {
       opacity: 0;
     }
 
-    .animate-fade-left\\.-observed, .stagger-fade-left\\.-observed > * {
+    .animate-fade-left.-observed, .stagger-fade-left.-observed > * {
       transform: translateX(0);
       opacity: 1;
     }
 
-    [class*="animate-"], [class*="stagger-"] > * {
-      transition-duration: 200ms;
+    [class*="stagger-"] > * {
+      --stagger-delay: 0s;
+      transition-delay: calc(var(--animate-index) * 100ms + var(--stagger-delay));
+    }
+
+    .stagger-interval-200 > * {
+      --stagger-delay: 0s;
+      transition-delay: calc(var(--animate-index) * 200ms + var(--stagger-delay));
     }
 
     .stagger-delay-100 > * {
-      transition-delay: calc(var(--animate-index) * 100ms);
+      --stagger-delay: 100ms;
     }
 
-    [class*="stagger-"] > * {
-      transition-delay: calc(var(--animate-index) * 50ms);
+    .stagger-delay-200 > * {
+      --stagger-delay: 200ms;
     }
 
     [class*="stagger"] > *:nth-child(1) {

--- a/plugins/animate/test.js
+++ b/plugins/animate/test.js
@@ -31,13 +31,19 @@ test('it generates the animate classes', () => {
               opacity: 1,
             },
           },
+          'zoom-in': {
+            from: {
+              transform: 'scale(0.8)',
+              opacity: 0,
+            },
+          },
         },
       },
     },
   }
 
   const output = `
-    .animate-fade-left, .stagger-fade-left > * {
+    .animate-fade-left:not(.-observed), .stagger-fade-left:not(.-observed) > * {
       transform: translateX(-20px);
       opacity: 0;
     }
@@ -45,6 +51,11 @@ test('it generates the animate classes', () => {
     .animate-fade-left.-observed, .stagger-fade-left.-observed > * {
       transform: translateX(0);
       opacity: 1;
+    }
+
+    .animate-zoom-in:not(.-observed), .stagger-zoom-in:not(.-observed) > * {
+      transform: scale(0.8);
+      opacity: 0;
     }
 
     [class*="stagger-"] > * {

--- a/plugins/animate/test.js
+++ b/plugins/animate/test.js
@@ -1,0 +1,85 @@
+const cssMatcher = require('jest-matcher-css')
+const plugin = require('./index')
+const { generateUtilities } = require('../../testing/generators')
+
+expect.extend({
+  toMatchCss: cssMatcher,
+})
+
+test('it generates the animate classes', () => {
+  const config = {
+    theme: {
+      animate: {
+        triggerClass: '-observed',
+        defaultDuration: 200,
+        staggerDelay: {
+          default: 50,
+          100: 100,
+        },
+        maxItemIntervalSupport: 5,
+        animations: {
+          'fade-left': {
+            from: {
+              transform: 'translateX(-20px)',
+              opacity: 0,
+            },
+            to: {
+              transform: 'translateX(0)',
+              opacity: 1,
+            },
+          },
+        },
+      },
+    },
+  }
+
+  const output = `
+    .animate-fade-left, .stagger-fade-left > * {
+      transform: translateX(-20px);
+      opacity: 0;
+    }
+
+    .animate-fade-left\\.-observed, .stagger-fade-left\\.-observed > * {
+      transform: translateX(0);
+      opacity: 1;
+    }
+
+    [class*="animate-"], [class*="stagger-"] > * {
+      transition-duration: 200ms;
+    }
+
+    .stagger-delay-100 > * {
+      transition-delay: calc(var(--animate-index) * 100ms);
+    }
+
+    [class*="stagger-"] > * {
+      transition-delay: calc(var(--animate-index) * 50ms);
+    }
+
+    [class*="stagger"] > *:nth-child(1) {
+      --animate-index: 1;
+    }
+
+    [class*="stagger"] > *:nth-child(2) {
+      --animate-index: 2;
+    }
+
+    [class*="stagger"] > *:nth-child(3) {
+      --animate-index: 3;
+    }
+
+    [class*="stagger"] > *:nth-child(4) {
+      --animate-index: 4;
+    }
+
+    [class*="stagger"] > *:nth-child(5) {
+      --animate-index: 5;
+    }
+  `
+
+  expect.assertions(2)
+  return generateUtilities(plugin, config).then((result) => {
+    expect(result.warnings().length).toBe(0)
+    expect(result.css).toMatchCss(output)
+  })
+})


### PR DESCRIPTION
Easier version of the README to read [here](https://github.com/vigetlabs/tailwindcss-plugins/blob/gk/animate/plugins/animate/README.md)

This was directly inspired by some Viget.com work and a general trend towards our designers wanting to apply these more often.

The README explains the purpose and usage, but one thing I'm especially curious about the verbiage in general that I used. I'll admit that an `animate` plugin is not obviously different from the `animation` utilities, but it's a rather tricky thing to pin down in a simple name. In short, this generates utilities that would generally be used with Intersection Observer in order to achieve "animate on scroll" or "scroll reveal" type functionalities (those are both existing library names). This plugin isn't intrinsically tied to scrolling, though, so not sure how much that makes sense to mention.

In addition, I went with `animate-` and `stagger-` utilities -- let me know how you feel about all these as well!

## Demo
Made a CodePen with some of the outputted utilities to demonstrate some of these (the `triggerClass` is just being toggled in a `setInterval` as opposed to being added via Intersection Observer):
https://codepen.io/gregkohn/pen/abNVQry?editors=1000