### PR TITLE
docs: correct 'require' paths, and dot notation pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const { em, rem, remPair, pxPair } = require('@viget/tailwindcss-plugins/utiliti
 
 // plugins
 plugins: [
-  require('@viget/tailwindcss-plugins/PLUGIN_NAME'),
+  require('@viget/tailwindcss-plugins/plugins/PLUGIN_NAME'),
   // ...
 ],
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn add @viget/tailwindcss-plugins -D
 
 ## Usage
 
-Simply require the plugins or utilities in your `tailwindcss.config.js` file, and follow the usage instructions for each documented in its folder.
+Simply require the plugins or utilities in your `tailwindcss.config.js` file. Plugin-specific instructions are in each plugin's README — see the [plugins directory](plugins/).
 
 ```js
 // utilities
@@ -40,10 +40,28 @@ const { em, rem, remPair, pxPair } = require('@viget/tailwindcss-plugins/utiliti
 
 // plugins
 plugins: [
-  require('@viget/tailwindcss-plugins/plugins/PLUGIN_NAME'),
+  require('@viget/tailwindcss-plugins/plugins/<plugin name>'),
   // ...
 ],
 ```
+
+Every plugin is also available as a node on the package's default export, so you can also
+
+```js
+// utilities
+const a = require('@viget/tailwindcss-plugins/utilities/alpha')
+const { em, rem, remPair, pxPair } = require('@viget/tailwindcss-plugins/utilities/fns')
+
+// plugins
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+
+plugins: [
+  vigetPlugins.<plugin handle>,
+  // ...
+],
+```
+
+See [index.js](index.js) or the plugins' READMEs for the handles.
 
 ## Testing
 

--- a/plugins/animate/README.md
+++ b/plugins/animate/README.md
@@ -43,7 +43,7 @@ theme: {
   }),
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/animate'),
+  require('@viget/tailwindcss-plugins/plugins/animate'),
 ],
 ```
 

--- a/plugins/animate/README.md
+++ b/plugins/animate/README.md
@@ -47,6 +47,50 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    animate: (theme) => ({
+      triggerClass: '-observed',
+      staggerDelay: {
+        '100': '100ms',
+        '200': '200ms',
+        ...theme('transitionDelay'),
+      },
+      staggerInterval: {
+        default: '100ms',
+        '200': '200ms',
+        ...theme('transitionDelay'),
+      },
+      maxItemIntervalSupport: 9,
+      animations: {
+        'fade-up': {
+          from: {
+            transform: 'translateY(20px)',
+            opacity: 0,
+          },
+          to: {
+            transform: 'translateY(0)',
+            opacity: 1,
+          },
+        },
+        'zoom-in': {
+          from: {
+            transform: 'scale(0.8)',
+            opacity: 0,
+          },
+          // "to" is optional
+        },
+      },
+    }),
+  },
+  plugins: [vigetPlugins.animate],
+}
+```
+
 ### Markup Examples
 
 #### Animate a single element (pending addition of `triggerClass`)

--- a/plugins/animation/README.md
+++ b/plugins/animation/README.md
@@ -17,7 +17,7 @@ theme: {
   },
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/animation'),
+  require('@viget/tailwindcss-plugins/plugins/animation'),
 ],
 ```
 

--- a/plugins/animation/README.md
+++ b/plugins/animation/README.md
@@ -21,6 +21,26 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    animation: {
+      spin: {
+        animation: '1s infinite linear',
+        keyframes: {
+          from: { transform: 'rotate(0deg)' },
+          to: { transform: 'rotate(360deg)' },
+        },
+      },
+    },
+  },
+  plugins: [vigetPlugins.animation],
+}
+```
+
 Note that this plugin does not accept **variants** so you do not need to add anything to that object.
 
 The above configuration would create the following css:

--- a/plugins/background/README.md
+++ b/plugins/background/README.md
@@ -20,6 +20,25 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    background: {
+      glow:
+        'radial-gradient(58.13% 57.41% at 49.33% 78.4%, rgba(208, 2, 27, 0.6) 0%)',
+      texture: `#111 url('../assets/images/texture.png') 0 0 / 24px 26px`,
+    },
+  },
+  variants: {
+    background: ['responsive'], // defaults to []
+  },
+  plugins: [vigetPlugins.background],
+}
+```
+
 The above configuration would create the following css, as well as their responsive variants:
 
 ```css

--- a/plugins/background/README.md
+++ b/plugins/background/README.md
@@ -16,7 +16,7 @@ variants: {
   background: ['responsive'], // defaults to []
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/background'),
+  require('@viget/tailwindcss-plugins/plugins/background'),
 ],
 ```
 

--- a/plugins/blend/README.md
+++ b/plugins/blend/README.md
@@ -15,7 +15,7 @@ variants: {
   blend: ['responsive'], // defaults to []
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/blend'),
+  require('@viget/tailwindcss-plugins/plugins/blend'),
 ],
 ```
 

--- a/plugins/blend/README.md
+++ b/plugins/blend/README.md
@@ -19,6 +19,24 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    blend: [
+      'multiply',
+      'screen',
+    ],
+  },
+  variants: {
+    blend: ['responsive'], // defaults to []
+  },
+  plugins: [vigetPlugins.blend],
+}
+```
+
 The above configuration would create the following css, as well as their responsive variants:
 
 ```css

--- a/plugins/filter/README.md
+++ b/plugins/filter/README.md
@@ -19,7 +19,7 @@ variants: {
   filter: ['responsive'], // defaults to []
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/filter'),
+  require('@viget/tailwindcss-plugins/plugins/filter'),
 ],
 ```
 

--- a/plugins/filter/README.md
+++ b/plugins/filter/README.md
@@ -23,6 +23,28 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    filter: {
+      blur: {
+        10: '10px',
+      },
+      saturate: {
+        0: 0,
+      },
+    },
+  },
+  variants: {
+    filter: ['responsive'], // defaults to []
+  },
+  plugins: [vigetPlugins.filter],
+}
+```
+
 The above configuration would create the following css, as well as their responsive variants:
 
 ```css

--- a/plugins/flex-basis/README.md
+++ b/plugins/flex-basis/README.md
@@ -14,7 +14,7 @@ variants: {
   flexBasis: ['responsive'], // defaults to []
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/flex-basis'),
+  require('@viget/tailwindcss-plugins/plugins/flex-basis'),
 ],
 ```
 

--- a/plugins/flex-basis/README.md
+++ b/plugins/flex-basis/README.md
@@ -18,6 +18,23 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    flexBasis: {
+      '200': '200px',
+    },
+  },
+  variants: {
+    flexBasis: ['responsive'], // defaults to []
+  },
+  plugins: [vigetPlugins.flexBasis],
+}
+```
+
 The above configuration would create the following css, as well as their responsive variants:
 
 ```css

--- a/plugins/gradient/README.md
+++ b/plugins/gradient/README.md
@@ -15,7 +15,7 @@ variants: {
   gradient: ['responsive'], // defaults to []
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/gradient'),
+  require('@viget/tailwindcss-plugins/plugins/gradient'),
 ],
 ```
 

--- a/plugins/gradient/README.md
+++ b/plugins/gradient/README.md
@@ -19,6 +19,24 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    gradient: theme => ({
+      '90-blue': `90deg, ${theme('colors.blue.400')} 50%, transparent`,
+      '270-blue': `270deg, ${theme('colors.blue.400')}, transparent`
+    }),
+  },
+  variants: {
+    gradient: ['responsive'], // defaults to []
+  },
+  plugins: [vigetPlugins.gradient],
+}
+```
+
 The above configuration would create the following css, as well as their responsive variants:
 
 ```css

--- a/plugins/parent-expanded/README.md
+++ b/plugins/parent-expanded/README.md
@@ -18,6 +18,23 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    rotate: {
+      '180': '180deg',
+    },
+  },
+  variants: {
+    rotate: ['parent-expanded'],
+  },
+  plugins: [vigetPlugins.parentExpanded],
+}
+```
+
 The above configuration would create the following css:
 
 ```css

--- a/plugins/parent-expanded/README.md
+++ b/plugins/parent-expanded/README.md
@@ -14,8 +14,7 @@ variants: {
   rotate: ['parent-expanded'],
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/parent-expanded'),
-  // ...
+  require('@viget/tailwindcss-plugins/plugins/parent-expanded'),
 ],
 ```
 

--- a/plugins/parent-open/README.md
+++ b/plugins/parent-open/README.md
@@ -14,8 +14,7 @@ variants: {
   rotate: ['parent-open'],
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/parent-open'),
-  // ...
+  require('@viget/tailwindcss-plugins/plugins/parent-open'),
 ],
 ```
 

--- a/plugins/parent-open/README.md
+++ b/plugins/parent-open/README.md
@@ -18,6 +18,15 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  plugins: [vigetPlugins.parentOpen],
+}
+```
+
 The above configuration would create the following css:
 
 ```css

--- a/plugins/rect/README.md
+++ b/plugins/rect/README.md
@@ -19,6 +19,26 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  theme: {
+    rect: {
+      target: [44, 44],
+      '24': [24, 24],
+    },
+  }
+  variants: {
+    rect: ['responsive'],
+  },
+  plugins: [
+    vigetPlugins.rect,
+  ],
+}
+```
+
 The above configuration would create the following css, as well as their responsive variants:
 
 ```css

--- a/plugins/rect/README.md
+++ b/plugins/rect/README.md
@@ -15,7 +15,7 @@ variants: {
   rect: ['responsive'],
 },
 plugins: [
-  require('@viget/tailwindcss-plugins/rect'),
+  require('@viget/tailwindcss-plugins/plugins/rect'),
 ],
 ```
 

--- a/plugins/sr/README.md
+++ b/plugins/sr/README.md
@@ -14,7 +14,7 @@ corePlugins: [
   accessibility: false,
 ],
 plugins: [
-  require('@viget/tailwindcss-plugins/sr'),
+  require('@viget/tailwindcss-plugins/plugins/sr'),
 ],
 ```
 

--- a/plugins/sr/README.md
+++ b/plugins/sr/README.md
@@ -18,6 +18,23 @@ plugins: [
 ],
 ```
 
+or
+
+```js
+const vigetPlugins = require('@viget/tailwindcss-plugins')
+module.exports = {
+  variants: {
+    sr: ['responsive'], // defaults to []
+  },
+  corePlugins: [
+    accessibility: false,
+  ],
+  plugins: [
+    vigetPlugins.sr,
+  ],
+}
+```
+
 The above configuration would create the following css, as well as their responsive variants:
 
 ```css


### PR DESCRIPTION
README updates:

1. Following the documentation resulted in a compilation error because `plugins/` was missing from all `require(…)`s. Now it's there!
1. The `require('@viget/tailwindcss-plugins')` + `plugins.<handle>` pattern Viget commonly uses was not documented. Now it is!

Greg requesting your review as the most recent and biggest contributor. Feel free to pull in anyone else who should be in that list. Should we add a CODEOWNERS?