### PR TITLE
documentation updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,8 @@ Each plugin is tested using [Jest](https://jestjs.io/). The easiest way to get s
 
 ### Structure
 
-- Output (required): Define what the generated CSS should look like. Jest makes this easy to debug but some things to remember:
-  - Double-escape `:`, i.e. `\\:`
-  - Order matters
-  - Testing variants also generates the basic version of the class
-- Config (almost always required): Define the user config for generating the CSS. For a plugin like [sr](/plugins/sr), the only configurable thing we are testing is variants, but most plugins require a theme passed as well. Testing variant plugins requires also passing an array of enabled `corePlugins`, as these are all turned off by default (see [parent-expanded](/plugins/parent-expanded) for an example).
+- **Output**: Define what the generated CSS should look like.
+- **Config**: Define the content string to use for generating the CSS. Most plugins require a theme passed as well.
 
 ## Documenting changes and releases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,45 @@
 
 Please review this document before submitting a pull request.
 
+## Setup
+
+To get started with local development,
+
+1. Install the correct version of Node.
+
+```bash
+asdf install
+```
+
+1. Install `package.json` dependencies. Versions are locked in `yarn.lock`, so installing them with Yarn is recommended.
+
+```bash
+yarn
+````
+
+See our [How to use local Node packages as project dependencies](https://www.viget.com/articles/how-to-use-local-unpublished-node-packages-as-project-dependencies/) article to use your development version in a project.
+
 ## Coding standards
 
-Our code formatting rules are defined in .prettierrc. Use [Prettier](https://prettier.io/) to format your code against these standards by running `package.json`'s `format` script. Method varies by Node.js package manager, e.g. `yarn format`.
+Our code formatting rules are defined in .prettierrc. You can format your code against these standards using [Prettier](https://prettier.io/) via the `format` script in `package.json`.
+
+```bash
+yarn format
+```
 
 ## Running tests
 
-To test all plugins, run `package.json`'s `test` script. Method varies by Node.js package manager, e.g. `yarn test`.
+To test all plugins, run the `test` script in `package.json`.
 
-To test a specific plugin, run `package.json`'s `test` script passing it the test file's path. Method varies by Node.js package manager, e.g. `yarn test plugins/my-plugin/test`.
+```bash
+yarn test
+```
+
+To test a specific plugin, run the `test` script in `package.json` passing it the test file's path.
+
+```bash
+yarn test plugins/my-plugin/test
+```
 
 ## Writing tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,20 @@
 # Contributing
 
-Please take a moment to review this document before submitting a pull request.
+Please review this document before submitting a pull request.
 
 ## Coding standards
 
-Our code formatting rules are defined in .prettierrc. You can automatically format your code against these standards by running:
-
-```bash
-yarn format
-```
+Our code formatting rules are defined in .prettierrc. Use [Prettier](https://prettier.io/) to format your code against these standards by running `package.json`'s `format` script. Method varies by Node.js package manager, e.g. `yarn format`.
 
 ## Running tests
 
-You can run the test suite using the following commands:
+To test all plugins, run `package.json`'s `test` script. Method varies by Node.js package manager, e.g. `yarn test`.
 
-```bash
-yarn test
-```
+To test a specific plugin, run `package.json`'s `test` script passing it the test file's path. Method varies by Node.js package manager, e.g. `yarn test plugins/my-plugin/test`.
 
 ## Writing tests
 
-Each plugin is tested using Jest. The easiest way to get started is by looking at existing tests.
+Each plugin is tested using [Jest](https://jestjs.io/). The easiest way to get started is by looking at existing tests.
 
 ### Structure
 
@@ -33,4 +27,4 @@ Each plugin is tested using Jest. The easiest way to get started is by looking a
 ## Documenting changes and releases
 
 - Add notes to the unreleased section in the CHANGELOG, with summaries of any additions, fixes, updates, or deprecations.
-- When a new version is released, those notes will be moved to the appropriate version number in the CHANGELOG.
+- When a new version is released, a maintainer will move those notes to the appropriate version number in the CHANGELOG.

--- a/README.md
+++ b/README.md
@@ -14,17 +14,11 @@ Utilities include:
 
 ## Installation
 
-```bash
-# install via npm
-npm i @viget/tailwindcss-plugins -D
-
-# install via yarn
-yarn add @viget/tailwindcss-plugins -D
-```
+Add `@viget/tailwindcss-plugins` to your `package.json` `devDependencies`. Method varies by Node package manager, e.g. `yarn add -D @viget/tailwindcss-plugins`.
 
 ## Usage
 
-Simply require the plugins or utilities in your `tailwindcss.config.js` file, and follow the usage instructions for each documented in its folder.
+Simply require the plugins or utilities in your `tailwindcss.config.js` file, and follow the usage instructions in the plugin's README (e.g. `https://github.com/vigetlabs/tailwindcss-plugins/plugins/PLUGIN_NAME/README.md`).
 
 ```js
 // utilities
@@ -38,12 +32,22 @@ plugins: [
 ],
 ```
 
+## Contributing
+
+Please review [CONTRIBUTING.md](./CONTRIBUTING.md) before submitting a pull request.
+
+To get started with local development,
+
+1. Install the `.nvmrc` Node.js version. Method varies by Node.js version manager, e.g. run `asdf install`.
+1. Install `package.json` dependencies. Versions are locked in `yarn.lock`, so installing them with Yarn is recommended: run `yarn`.
+
+See our [How to use local Node packages as project dependencies](https://www.viget.com/articles/how-to-use-local-unpublished-node-packages-as-project-dependencies/) article to use your development version in a project.
+
 ## Testing
 
-Run tests:
-```bash
-yarn test
-```
+To test all plugins, run `package.json`'s `test` script. Method varies by Node.js package manager, e.g. `yarn test`.
+
+To test a specific plugin, run `package.json`'s `test` script passing it the test file's path. Method varies by Node.js package manager, e.g. `yarn test plugins/my-plugin/test`.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,15 @@ Utilities include:
 
 ## Installation
 
-Add `@viget/tailwindcss-plugins` to your `package.json` `devDependencies`. Method varies by Node package manager, e.g. `yarn add -D @viget/tailwindcss-plugins`.
+Add `@viget/tailwindcss-plugins` to `devDependencies` in `package.json`.
+
+```bash
+yarn add -D @viget/tailwindcss-plugins
+```
 
 ## Usage
 
-Simply require the plugins or utilities in your `tailwindcss.config.js` file, and follow the usage instructions in the plugin's README (e.g. `https://github.com/vigetlabs/tailwindcss-plugins/plugins/PLUGIN_NAME/README.md`).
+Simply require the plugins or utilities in your `tailwindcss.config.js` file, and follow the usage instructions in each plugin's README.
 
 ```js
 // utilities
@@ -31,23 +35,6 @@ plugins: [
   // ...
 ],
 ```
-
-## Contributing
-
-Please review [CONTRIBUTING.md](./CONTRIBUTING.md) before submitting a pull request.
-
-To get started with local development,
-
-1. Install the `.nvmrc` Node.js version. Method varies by Node.js version manager, e.g. run `asdf install`.
-1. Install `package.json` dependencies. Versions are locked in `yarn.lock`, so installing them with Yarn is recommended: run `yarn`.
-
-See our [How to use local Node packages as project dependencies](https://www.viget.com/articles/how-to-use-local-unpublished-node-packages-as-project-dependencies/) article to use your development version in a project.
-
-## Testing
-
-To test all plugins, run `package.json`'s `test` script. Method varies by Node.js package manager, e.g. `yarn test`.
-
-To test a specific plugin, run `package.json`'s `test` script passing it the test file's path. Method varies by Node.js package manager, e.g. `yarn test plugins/my-plugin/test`.
 
 ## Notes
 


### PR DESCRIPTION
- With pnpm gaining popularity, don't try to give sample commands for all possible package managers
- Document method for testing a single plugin
- Add local development dependency installation instructions
- Don't assume reading speed
- Link Jest and Prettier
- Link our Yalc blog post