### PR TITLE
Restore animate plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the text-underline-position plugin
 
 ### Removed
-- Removed animate plugin
 - Removed animation plugin
 - Removed background plugin
 - Removed blend plugin

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This plugin wraps up a collection of other plugins we've written for [Tailwind CSS](https://tailwindcss.com/).
 
 Plugins include:
+* [animate](/plugins/animate/)
 * [parent-expanded](/plugins/parent-expanded/)
 * [parent-open](/plugins/parent-open/)
 * [rect](/plugins/rect/)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  animate: require('./plugins/animate'),
   parentExpanded: require('./plugins/parent-expanded'),
   parentOpen: require('./plugins/parent-open'),
   rect: require('./plugins/rect'),

--- a/plugins/animate/README.md
+++ b/plugins/animate/README.md
@@ -1,0 +1,120 @@
+# animate
+
+This plugin adds utilities for animating elements based on a dynamically added class. The main use case this addresses is animating elements in during scrolling. By adding a class via [Intersection Observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) or some other scroll listener, these utilities allow you to easily define the animations and apply staggered transitions. This has also been designed to work with the existing Tailwind utilities that control transition properties.
+
+## Usage
+
+### Config Example
+
+```js
+theme: {
+  animate: (theme) => ({
+    triggerClass: '-observed',
+    staggerDelay: {
+      '100': '100ms',
+      '200': '200ms',
+      ...theme('transitionDelay'),
+    },
+    staggerInterval: {
+      default: '100ms',
+      '200': '200ms',
+      ...theme('transitionDelay'),
+    },
+    maxItemIntervalSupport: 9,
+    animations: {
+      'fade-up': {
+        from: {
+          transform: 'translateY(20px)',
+          opacity: 0,
+        },
+        to: {
+          transform: 'translateY(0)',
+          opacity: 1,
+        },
+      },
+      'zoom-in': {
+        from: {
+          transform: 'scale(0.8)',
+          opacity: 0,
+        },
+        // "to" is optional
+      },
+    },
+  }),
+},
+plugins: [
+  require('@viget/tailwindcss-plugins/animate'),
+],
+```
+
+### Markup Examples
+
+#### Animate a single element (pending addition of `triggerClass`)
+
+```html
+<div class="animate-fade-up">Hello!</div>
+```
+
+---
+
+#### Animate a single element after a delay
+```html
+<div class="animate-fade-up delay-200">Hello</div>
+```
+> N.b. `delay-` is a first-party Tailwind utility
+
+---
+
+#### Stagger the animation of multiple elements, using the specified default interval
+```html
+<ul class="stagger-fade-up">
+  <li class="duration-500">1</li>
+  <li class="duration-500">2</li>
+  <li class="duration-500">3</li>
+</ul>
+```
+> N.b. `duration-` is a first-party Tailwind utility and **is required** on the child element unless a `transition-duration` is otherwise specified. This plugin doesn not apply a default duration in order to preserve customizability using the `duration-` utilities.
+
+---
+
+#### Stagger the animation of multiple elements, overriding default interval
+```html
+<ul class="stagger-fade-up stagger-interval-200">
+  <li class="duration-500">1</li>
+  <li class="duration-500">2</li>
+  <li class="duration-500">3</li>
+</ul>
+```
+
+---
+
+#### Stagger the animation of multiple elements, using specified interval, but delay the start
+```html
+<ul class="stagger-fade-up stagger-interval-200 stagger-delay-100">
+  <li class="duration-500">1</li>
+  <li class="duration-500">2</li>
+  <li class="duration-500">3</li>
+</ul>
+```
+
+## Configuration
+
+### `triggerClass`
+
+Specify the class name that will be dynamically added to the element. Typically this class is added to indicate that the element has entered the viewport.
+
+### `staggerDelay`
+
+Specify the delays for starting the staggered animations. It probably makes the most sense to simply set this to `theme('transitionDelay')`.
+
+### `staggerInterval`
+
+Specify the amount of time in between the staggered animations. While optional, it is recommended to add a `default` entry to this object. Doing so allows you to use the `stagger-[animation]` class without specifying any `stagger-interval-[time]`.
+
+### `maxItemIntervalSupport`
+
+The `transition-delay` used to power the staggered animation are calculated via a custom property on the child elements called `--animate-index`. This setting allows you to decide how many `nth-child` selectors should be automatically output with this custom property so you do not need to add it by hand. 
+
+### `animations`
+
+Specify the animation styles. The first-level object names the animation, which in turn **must** specify a `from` object and optionally a `to` object. These objects accept the same [CSS-in-JS syntax as Tailwind](https://tailwindcss.com/docs/plugins#css-in-js-syntax).

--- a/plugins/animate/index.js
+++ b/plugins/animate/index.js
@@ -1,0 +1,77 @@
+const plugin = require('tailwindcss/plugin')
+
+module.exports = plugin(({ addUtilities, e, theme }) => {
+  const pluginConfig = theme('animate', {})
+  const {
+    triggerClass,
+    staggerDelay,
+    staggerInterval,
+    maxItemIntervalSupport,
+    animations,
+  } = pluginConfig
+
+  const animationUtilities = Object.entries(animations).map(
+    ([name, config]) => {
+      const from = {
+        [`.${e(`animate-${name}`)}:not(.${e(triggerClass)}), .${e(
+          `stagger-${name}`,
+        )}:not(.${e(triggerClass)}) > *`]: config.from,
+      }
+
+      const to = config.to
+        ? {
+            [`.${e(`animate-${name}`)}.${e(triggerClass)},.${e(
+              `stagger-${name}`,
+            )}.${triggerClass} > *`]: config.to,
+          }
+        : {}
+
+      return {
+        ...from,
+        ...to,
+      }
+    },
+  )
+
+  const staggerDefaultUtility = staggerInterval.default
+    ? [
+        {
+          '[class*="stagger-"] > *': {
+            '--stagger-delay': '0s',
+            'transition-delay': `calc(var(--animate-index) * ${staggerInterval.default} + var(--stagger-delay))`,
+          },
+        },
+      ]
+    : []
+
+  const staggerIntervalUtilities = Object.entries(staggerInterval)
+    .filter(([name]) => name !== 'default')
+    .map(([name, value]) => ({
+      [`.${e(`stagger-interval-${name}`)} > *`]: {
+        '--stagger-delay': '0s',
+        'transition-delay': `calc(var(--animate-index) * ${value} + var(--stagger-delay))`,
+      },
+    }))
+
+  const staggerDelayUtilities = Object.entries(staggerDelay).map(
+    ([name, value]) => ({
+      [`.${e(`stagger-delay-${name}`)} > *`]: {
+        '--stagger-delay': value,
+      },
+    }),
+  )
+
+  const nthChildUtilities = [...Array(maxItemIntervalSupport)].map((_, i) => ({
+    [`[class*="stagger"] > *:nth-child(${i + 1})`]: {
+      '--animate-index': `${i + 1}`,
+    },
+  }))
+
+  addUtilities([
+    ...animationUtilities,
+    ...staggerDefaultUtility,
+    ...staggerIntervalUtilities,
+    ...staggerDelayUtilities,
+    ...nthChildUtilities,
+  ])
+})

--- a/plugins/animate/test.js
+++ b/plugins/animate/test.js
@@ -1,0 +1,105 @@
+const cssMatcher = require('jest-matcher-css')
+const plugin = require('./index')
+const { generateUtilities } = require('../../testing/generators')
+
+expect.extend({
+  toMatchCss: cssMatcher,
+})
+
+test('it generates the animate classes', () => {
+  const config = {
+    theme: {
+      animate: {
+        triggerClass: '-observed',
+        staggerDelay: {
+          '100': '100ms',
+          '200': '200ms',
+        },
+        staggerInterval: {
+          default: '100ms',
+          '200': '200ms',
+        },
+        maxItemIntervalSupport: 5,
+        animations: {
+          'fade-left': {
+            from: {
+              transform: 'translateX(-20px)',
+              opacity: 0,
+            },
+            to: {
+              transform: 'translateX(0)',
+              opacity: 1,
+            },
+          },
+          'zoom-in': {
+            from: {
+              transform: 'scale(0.8)',
+              opacity: 0,
+            },
+          },
+        },
+      },
+    },
+  }
+
+  const output = `
+    .animate-fade-left:not(.-observed), .stagger-fade-left:not(.-observed) > * {
+      transform: translateX(-20px);
+      opacity: 0;
+    }
+
+    .animate-fade-left.-observed, .stagger-fade-left.-observed > * {
+      transform: translateX(0);
+      opacity: 1;
+    }
+
+    .animate-zoom-in:not(.-observed), .stagger-zoom-in:not(.-observed) > * {
+      transform: scale(0.8);
+      opacity: 0;
+    }
+
+    [class*="stagger-"] > * {
+      --stagger-delay: 0s;
+      transition-delay: calc(var(--animate-index) * 100ms + var(--stagger-delay));
+    }
+
+    .stagger-interval-200 > * {
+      --stagger-delay: 0s;
+      transition-delay: calc(var(--animate-index) * 200ms + var(--stagger-delay));
+    }
+
+    .stagger-delay-100 > * {
+      --stagger-delay: 100ms;
+    }
+
+    .stagger-delay-200 > * {
+      --stagger-delay: 200ms;
+    }
+
+    [class*="stagger"] > *:nth-child(1) {
+      --animate-index: 1;
+    }
+
+    [class*="stagger"] > *:nth-child(2) {
+      --animate-index: 2;
+    }
+
+    [class*="stagger"] > *:nth-child(3) {
+      --animate-index: 3;
+    }
+
+    [class*="stagger"] > *:nth-child(4) {
+      --animate-index: 4;
+    }
+
+    [class*="stagger"] > *:nth-child(5) {
+      --animate-index: 5;
+    }
+  `
+
+  expect.assertions(2)
+  return generateUtilities(plugin, config).then((result) => {
+    expect(result.warnings().length).toBe(0)
+    expect(result.css).toMatchCss(output)
+  })
+})

--- a/plugins/animate/test.js
+++ b/plugins/animate/test.js
@@ -1,22 +1,31 @@
 const cssMatcher = require('jest-matcher-css')
 const plugin = require('./index')
-const { generateUtilities } = require('../../testing/generators')
+const { run } = require('../../testing/run')
 
 expect.extend({
   toMatchCss: cssMatcher,
 })
 
-test('it generates the animate classes', () => {
+it('should generate the animate classes', () => {
   const config = {
+    content: [
+      {
+        raw: String.raw`
+          <ul class="stagger-fade-left stagger-interval-200 stagger-delay-200">
+            <li class="duration-500">1</li>
+            <li class="duration-500">2</li>
+            <li class="duration-500">3</li>
+          </ul>
+        `,
+      },
+    ],
     theme: {
       animate: {
         triggerClass: '-observed',
         staggerDelay: {
-          '100': '100ms',
           '200': '200ms',
         },
         staggerInterval: {
-          default: '100ms',
           '200': '200ms',
         },
         maxItemIntervalSupport: 5,
@@ -31,74 +40,59 @@ test('it generates the animate classes', () => {
               opacity: 1,
             },
           },
-          'zoom-in': {
-            from: {
-              transform: 'scale(0.8)',
-              opacity: 0,
-            },
-          },
         },
       },
     },
   }
 
-  const output = `
+  const output = String.raw`
+    .duration-500 {
+      transition-duration: 500ms;
+    }
+
     .animate-fade-left:not(.-observed), .stagger-fade-left:not(.-observed) > * {
       transform: translateX(-20px);
       opacity: 0;
     }
 
-    .animate-fade-left.-observed, .stagger-fade-left.-observed > * {
+    .animate-fade-left.-observed,.stagger-fade-left.-observed > * {
       transform: translateX(0);
       opacity: 1;
     }
-
-    .animate-zoom-in:not(.-observed), .stagger-zoom-in:not(.-observed) > * {
-      transform: scale(0.8);
-      opacity: 0;
-    }
-
-    [class*="stagger-"] > * {
-      --stagger-delay: 0s;
-      transition-delay: calc(var(--animate-index) * 100ms + var(--stagger-delay));
-    }
-
+    
     .stagger-interval-200 > * {
       --stagger-delay: 0s;
       transition-delay: calc(var(--animate-index) * 200ms + var(--stagger-delay));
     }
-
-    .stagger-delay-100 > * {
-      --stagger-delay: 100ms;
-    }
-
+    
     .stagger-delay-200 > * {
       --stagger-delay: 200ms;
     }
-
+    
     [class*="stagger"] > *:nth-child(1) {
       --animate-index: 1;
     }
-
+    
     [class*="stagger"] > *:nth-child(2) {
       --animate-index: 2;
     }
-
+    
     [class*="stagger"] > *:nth-child(3) {
       --animate-index: 3;
     }
-
+    
     [class*="stagger"] > *:nth-child(4) {
       --animate-index: 4;
     }
-
+    
     [class*="stagger"] > *:nth-child(5) {
       --animate-index: 5;
     }
+
   `
 
   expect.assertions(2)
-  return generateUtilities(plugin, config).then((result) => {
+  return run(plugin, config).then((result) => {
     expect(result.warnings().length).toBe(0)
     expect(result.css).toMatchCss(output)
   })


### PR DESCRIPTION
I prematurely removed the animate plugin in #28. Some projects use observed and staggered animations provided by this plugin, and it's not something that is provided by Tailwind itself.